### PR TITLE
correctly handle `$(` subshells

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,18 @@ $ expenv -i -f inputfile // Replace inplace
 ```
 
 Example input:
-```bash
+```
 My PWD is $PWD
 Whoami: ${USER}
 I'm using $TERM
-Expand $empty but don't expand $$empty # => Expand  but don't expand $empty
+Expand $empty but don't expand $$empty
+Don't expand $(echo empty)
 ```
+
+As mentioned in the above example, two special cases exist:
+
+* `$$` is converted to `$`, allowing you to pass in literal-dollar-signs
+* `$(` is not converted, allowing your input to contain subshell like behaviour
 
 Motivation
 -----

--- a/expenv.go
+++ b/expenv.go
@@ -135,5 +135,10 @@ func FileReplaceWriteCloser(f *os.File, replacePath string) io.WriteCloser {
 // Follow os.ExpandEnv's contract except for `$$` which is transformed to `$`
 func expandEnv(s string) string {
 	os.Setenv("EXPENV_DOLLAR", "$")
-	return os.ExpandEnv(strings.Replace(s, "$$", "${EXPENV_DOLLAR}", -1))
+	os.Setenv("EXPENV_PARENTHESIS", "$(")
+
+	s = strings.Replace(s, "$$", "${EXPENV_DOLLAR}", -1)
+	s = strings.Replace(s, "$(", "${EXPENV_PARENTHESIS}", -1)
+
+	return os.ExpandEnv(s)
 }


### PR DESCRIPTION
one more edge-case that isn't handled by Go's default `expandEnv`.
